### PR TITLE
Run DCE on re-exports from a module

### DIFF
--- a/src/Language/PureScript/DCE/CoreFn.hs
+++ b/src/Language/PureScript/DCE/CoreFn.hs
@@ -25,7 +25,6 @@ data DCEVertex
   = BindVertex (Bind Ann)
   | ForeignVertex (Qualified Ident)
   | ReExportedVertex (Qualified Ident)
-  deriving (Show)
 
 
 -- | Dead code elimination of a list of modules module

--- a/test/Test/Lib.hs
+++ b/test/Test/Lib.hs
@@ -56,6 +56,7 @@ libTests =
       <> " }\n"
       )
       True
+  , LibTest ["Control.Alt.map"] Nothing "require('./dce-output/Control.Alt').map;" True
   ]
 
 


### PR DESCRIPTION
Purs 0.14 series added a `moduleReExports` field to the Module type which was initially left intact. This caused a problem when
re-exported names were eliminated in the code but left in the re-export list. This commit eliminates symbols from the re-export
list too and adds a test.