### PR TITLE
Fix traversal of CoreFn CaseAlternative Binders

### DIFF
--- a/test/Test/Lib.hs
+++ b/test/Test/Lib.hs
@@ -1,7 +1,6 @@
 module Test.Lib (spec) where
 
 import           Control.Monad.Except
-import           Control.Monad.Trans.Class
 import           Data.Text                 (Text)
 import qualified Data.Text                 as T
 import           Prelude                   ()

--- a/test/Test/Lib.hs
+++ b/test/Test/Lib.hs
@@ -1,24 +1,24 @@
 module Test.Lib (spec) where
 
-import           Prelude ()
-import           Prelude.Compat hiding (exp)
-import           Control.Monad.Trans.Class
 import           Control.Monad.Except
-import           Data.Text (Text)
-import qualified Data.Text as T
-import           System.Exit (ExitCode(..))
-import           System.Process (readProcessWithExitCode)
+import           Control.Monad.Trans.Class
+import           Data.Text                 (Text)
+import qualified Data.Text                 as T
+import           Prelude                   ()
+import           Prelude.Compat            hiding (exp)
+import           System.Exit               (ExitCode (..))
+import           System.Process            (readProcessWithExitCode)
+import           Test.HUnit                (assertEqual)
 import           Test.Hspec
-import           Test.HUnit (assertEqual)
 
 import           Test.Utils
 
 
 data LibTest = LibTest
-  { libTestEntries :: [Text]
+  { libTestEntries       :: [Text]
   , libTestZephyrOptions :: Maybe [Text]
-  , libTestJsCmd :: Text
-  , libTestShouldPass :: Bool
+  , libTestJsCmd         :: Text
+  , libTestShouldPass    :: Bool
   -- ^ true if it should run without error, false if it should error
   }
 
@@ -57,6 +57,7 @@ libTests =
       )
       True
   , LibTest ["Control.Alt.map"] Nothing "require('./dce-output/Control.Alt').map;" True
+  , LibTest ["Data.Array.span"] Nothing "require('./dce-output/Data.Array').span" True
   ]
 
 


### PR DESCRIPTION
Commit 5734b103c re-implemented the Purescript `everythingOnValues` function locally. While simplifying the function for the specific use-case vital functionality was left out for traversing `CaseAlternatives`. This commit re-introduces the removed functionality and adds a regression test.